### PR TITLE
Fix warning when pwa module doesn't provide a version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming release]
  - Fixed Drupal 9 compatibility when pwa is enabled.
+ - Fixed warning when PWA module didn't provide a version.
 
 ## [2.4.8]
  - Updated REST endpoints for assessment to work with Drupal 9

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -119,14 +119,10 @@ class Settings {
 
     // Look up module release from package info.
     $this->moduleExtensionList->getExtensionInfo('pwa');
-    $pwa_module_version = $pwa_module_info['version'];
-
     // Packaging script will always provide the published module version.
     // Checking for NULL is only so maintainers have something
     // predictable to test against.
-    if ($pwa_module_version == NULL) {
-      $pwa_module_version = '8.x-1.x-dev';
-    }
+    $pwa_module_version = $pwa_module_info['version'] ?? '8.x-1.x-dev';
 
     return [
       'current_cache' => 'pwa-main-' . $pwa_module_version . '-v' . ($config->get('cache_version') ?: 1),


### PR DESCRIPTION
No Changelog modification since is a fix on the latest unrelease change.