### PR TITLE
Disabled cache when the progress is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 -
 
+## [2.5.6]
+- Disabled cache when the progress is enabled.
+
 ## [2.5.5]
 - Improved page loading performance by adding caching for serialized data.
 

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\anu_lms;
 
-use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -145,8 +144,15 @@ class Normalizer {
     // Normalize recursively given entity.
     $normalized_entity = $this->serializer->normalize($entity, 'json_recursive', $context);
 
+    /** @var \Drupal\Core\Cache\CacheableMetadata $cacheable_metadata */
+    $cacheable_metadata = $context[$cacheable_key];
     // Saving normalized entity to the cache for further usage.
-    $this->cache->set($cache_cid, $normalized_entity, Cache::PERMANENT, $context[$cacheable_key]->getCacheTags());
+    $this->cache->set(
+      $cache_cid,
+      $normalized_entity,
+      $cacheable_metadata->getCacheMaxAge(),
+      $cacheable_metadata->getCacheTags(),
+    );
 
     return $normalized_entity;
   }

--- a/src/Normalizer/NodeNormalizer.php
+++ b/src/Normalizer/NodeNormalizer.php
@@ -61,6 +61,15 @@ class NodeNormalizer extends ContentEntityNormalizer {
 
     if ($entity->bundle() === 'course' && $courseHandler->isLinearProgressEnabled($entity)) {
       $normalized['progress'] = $courseProgressHandler->getCourseProgress($entity);
+
+      // If progress is enabled, we disable all REST Entity Recursive cache!
+      // @todo extract progress data in a separate data attribute and enable
+      // back cache.
+      if (isset($context[static::SERIALIZATION_CONTEXT_CACHEABILITY])) {
+        /** @var \Drupal\Core\Cache\CacheableMetadata $cacheable_metadata */
+        $cacheable_metadata = $context[static::SERIALIZATION_CONTEXT_CACHEABILITY];
+        $cacheable_metadata->setCacheMaxAge(0);
+      }
     }
 
     if (


### PR DESCRIPTION
It's a regression from https://github.com/systemseed/anu_lms/pull/183

As a quick solution, we disable cache if progress is enabled for the course. 